### PR TITLE
Use `function-bind` to preserve ES3 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     }
   ],
   "main": "./src/index",
+  "dependencies": {
+    "function-bind": "^1.0.2"
+  },
   "devDependencies": {
     "chai": "~1.7.2",
     "mocha": "^1.21.4"
@@ -30,8 +33,5 @@
   },
   "scripts": {
     "test": "node_modules/mocha/bin/mocha"
-  },
-  "dependencies": {
-    "function-bind": "^1.0.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,3 @@
-Function.prototype.bind = require("function-bind");
-var hasOwn = Object.prototype.hasOwnProperty;
+var bind = require('function-bind');
 
-module.exports = function has(obj, property) {
-  return hasOwn(obj, property);
-};
+module.exports = bind.call(Function.call, Object.prototype.hasOwnProperty);


### PR DESCRIPTION
This restores ES3 compatibility, lost in #2. This also doesn't modify globals as #3 does.