### PR TITLE
Remove non-essential files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,13 @@
+# gitignore
 /node_modules/
+/build/
 *.log
 *~
+
+# Only apps should have lockfiles
+npm-shrinkwrap.json
+package-lock.json
+yarn.lock
+
+.eslintrc
+.npmrc


### PR DESCRIPTION
An alternative would be to add the following to package.json, which would take care of everything:

```
files: ['src']
```
