### PR TITLE
[BREAKING CHANGE] Drop ES3 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "Thiago de Arruda",
     "email": "tpadilha84@gmail.com"
   },
- "contributors": [
+  "contributors": [
     {
       "name": "Jordan Harband",
       "email": "ljharb@gmail.com",
@@ -29,9 +29,6 @@
     }
   ],
   "main": "./src",
-  "dependencies": {
-    "function-bind": "^1.1.1"
-  },
   "devDependencies": {
     "@ljharb/eslint-config": "^12.2.1",
     "eslint": "^4.19.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
 'use strict';
 
-var bind = require('function-bind');
-
-module.exports = bind.call(Function.call, Object.prototype.hasOwnProperty);
+module.exports = Function.call.bind(Object.prototype.hasOwnProperty);


### PR DESCRIPTION
Every JS interpreter released since 2011 supports `Function.prototype.bind`. Can we make a Semver Major new release that eliminates the dependency?