### PR TITLE
test: Assert that `has(…)` throws on `null` or `undefined`

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -6,5 +6,11 @@ var has = require('../');
 test('has', function (t) {
   t.equal(has({}, 'hasOwnProperty'), false, 'object literal does not have own property "hasOwnProperty"');
   t.equal(has(Object.prototype, 'hasOwnProperty'), true, 'Object.prototype has own property "hasOwnProperty"');
+  t['throws'](function () {
+    has(null, 'throws');
+  }, TypeError, 'calling has on null throws TypeError');
+  t['throws'](function () {
+    has(void 0, 'throws');
+  }, TypeError, 'calling has on undefined throws TypeError');
   t.end();
 });


### PR DESCRIPTION
Currently, calling&nbsp;<code>has(null,&nbsp;"foo")</code> or&nbsp;<code>has(undefined,&nbsp;"foo")</code> throws a&nbsp;<code>TypeError</code>:
```
TypeError: Cannot convert undefined or null to object
    at hasOwnProperty (<anonymous>)
```

Should I change this so that calling `has(…)` on `null` and `undefined` return `false` instead?

---

closes #13