### PR TITLE
fix: `has(…)` returns `false` on `null` or `undefined`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,12 @@
 'use strict';
 
 var bind = require('function-bind');
+var hasImpl = bind.call(Function.call, Object.prototype.hasOwnProperty);
 
-module.exports = bind.call(Function.call, Object.prototype.hasOwnProperty);
+module.exports = function hasOwnProperty(target) {
+  if (target === null || target === void 0) {
+    return false;
+  }
+
+  return hasImpl.apply(void 0, arguments);
+};

--- a/test/index.js
+++ b/test/index.js
@@ -6,5 +6,7 @@ var has = require('../');
 test('has', function (t) {
   t.equal(has({}, 'hasOwnProperty'), false, 'object literal does not have own property "hasOwnProperty"');
   t.equal(has(Object.prototype, 'hasOwnProperty'), true, 'Object.prototype has own property "hasOwnProperty"');
+  t.equal(has(null, 'hasOwnProperty'), false, 'null does not have own property "hasOwnProperty"');
+  t.equal(has(void 0, 'hasOwnProperty'), false, 'undefined does not have own property "hasOwnProperty"');
   t.end();
 });


### PR DESCRIPTION
Currently, calling&nbsp;<code>has(null,&nbsp;"foo")</code> or&nbsp;<code>has(undefined,&nbsp;"foo")</code> throws a&nbsp;<code>TypeError</code>:
```
TypeError: Cannot convert undefined or null to object
    at hasOwnProperty (<anonymous>)
```

This&nbsp;makes it&nbsp;so&nbsp;that calling&nbsp;<code>has(null,&nbsp;"foo")</code> or&nbsp;<code>has(undefined,&nbsp;"foo")</code> returns&nbsp;<code>false</code> instead.

---

closes #12