### PR TITLE
Drop `function-bind` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,6 @@
     }
   ],
   "main": "./src",
-  "dependencies": {
-    "function-bind": "^1.1.1"
-  },
   "devDependencies": {
     "@ljharb/eslint-config": "^12.2.1",
     "eslint": "^4.19.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const hasOwnProperty = Object.prototype.hasOwnProperty;
 module.exports = function (object, property) {
-  return Object.prototype.hasOwnProperty.call(object, property);
+  return hasOwnProperty.call(object, property);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
-var bind = require('function-bind');
-
-module.exports = bind.call(Function.call, Object.prototype.hasOwnProperty);
+module.exports = function (object, property) {
+  return Object.prototype.hasOwnProperty.call(object, property);
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const hasOwnProperty = Object.prototype.hasOwnProperty;
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
 module.exports = function (object, property) {
   return hasOwnProperty.call(object, property);
 };


### PR DESCRIPTION
I noticed that function-bind is 50 lines long while this package is essentially a single line of code. The current code should preserve Node 0.4 compatibility without importing a lengthy polyfill