### PR TITLE
Drop `function-bind` dependency with saving safety

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,6 @@
     }
   ],
   "main": "./src",
-  "dependencies": {
-    "function-bind": "^1.1.1"
-  },
   "devDependencies": {
     "@ljharb/eslint-config": "^12.2.1",
     "eslint": "^4.19.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var hasOwnProperty = {}.hasOwnProperty;
-var call = hasOwnProperty.call;
+var call = Function.prototype.call;
 
 module.exports = call.bind ? call.bind(hasOwnProperty) : function (O, P) {
   return call.call(hasOwnProperty, O, P);

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 'use strict';
 
-var bind = require('function-bind');
+var hasOwnProperty = {}.hasOwnProperty;
+var call = hasOwnProperty.call;
 
-module.exports = bind.call(Function.call, Object.prototype.hasOwnProperty);
+module.exports = call.bind ? call.bind(hasOwnProperty) : function (O, P) {
+  return call.call(hasOwnProperty, O, P);
+};


### PR DESCRIPTION
That reduces the minified size of the package from 1KB to a hundred bytes.

[The argument about protection from `delete Function.prototype.call`](https://github.com/tarruda/has/pull/16) does not work here since in ES5+ engines `.call` is not used after loading, but [in ES3 engines `function-bind` use `.call` internally anyway](https://github.com/Raynos/function-bind/blob/f69aaa2beb2fdab4415bfb885760a699d0b9c964/implementation.js#L31).

The argument that "most likely you have `function-bind` in your dependencies chain" also does not work - I haven't it in any other places.